### PR TITLE
[12] base_optional_quick_create: avoid a crash during migration (up-port from v10)

### DIFF
--- a/base_optional_quick_create/models/ir_model.py
+++ b/base_optional_quick_create/models/ir_model.py
@@ -27,7 +27,7 @@ class IrModel(models.Model):
         method_name = 'name_create'
         for model in self:
             model_obj = self.env.get(model.model)
-            if model.avoid_quick_create:
+            if model.avoid_quick_create and model_obj is not None:
                 model_obj._patch_method(method_name, _wrap_name_create())
             else:
                 method = getattr(model_obj, method_name, None)


### PR DESCRIPTION
This is the PR that added the fix in v10: https://github.com/OCA/server-tools/pull/1222/files